### PR TITLE
do not fail if file to be deleted is absent

### DIFF
--- a/api-harvest-assembly/api-node/userconfig/startBroker.sh
+++ b/api-harvest-assembly/api-node/userconfig/startBroker.sh
@@ -7,7 +7,7 @@ if [ -e "/state/api-node-0-broker" ]; then
 fi
 
 cd /data
-rm /data/startup/datadir-initialized
+rm -f /data/startup/datadir-initialized
 
 touch /state/api-node-0-broker
 


### PR DESCRIPTION
I goe an error on this, and adding the flag `-f` to `rm` fixes it.